### PR TITLE
Updated build scripts

### DIFF
--- a/.github/scripts/CreateAvailablePreReleaseVersion.ps1
+++ b/.github/scripts/CreateAvailablePreReleaseVersion.ps1
@@ -1,0 +1,28 @@
+param([string] $Version, [string] $PreReleaseName = "beta")
+
+if (![Regex]::Match($Version, '^\d+\.\d+\.\d+$').Success) {
+    Write-Output("Version should be formatted x.x.x");
+    exit(1);
+}
+
+$result = "$Version-$PreReleaseName-01";
+$tagData = git show-ref --tags
+$existingTags = @();
+ForEach ($line in $( $tagData -split "`r`n" ))
+{
+    $tag = [Regex]::Match($line, 'refs/tags/v?(.*)$').Captures.Groups[1].Value;
+    $existingTags += $tag;
+}
+
+$count = 1;
+while($existingTags.Contains($result))
+{
+    $versionElement = [Regex]::Match($result, '(\d+\.\d+\.\d+-' + $PreReleaseName + ')').Captures.Groups[1].Value;
+    $indexString = "-{0:d2}" -f $count
+    $result = $versionElement + $indexString;
+    $count ++;
+}
+
+Write-Output $result;
+
+exit(0)

--- a/.github/scripts/CreateVersionTitle.ps1
+++ b/.github/scripts/CreateVersionTitle.ps1
@@ -1,0 +1,24 @@
+param([string] $Version)
+
+if (![Regex]::Match($Version, '^\d+\.\d+\.\d+.*').Success) {
+    Write-Output("Version should be formatted x.x.x");
+    exit(1);
+}
+
+$r = [Regex]::Match($Version, '(\d+\.\d+\.\d+)(?:-(\w+)-(\d+))?');
+
+$baseVersion = $r.Captures.Groups[1].Value;
+
+$result = "v$baseVersion";
+
+if($r.Captures.Groups[2].Success)
+{
+    $releaseType = $r.Captures.Groups[2].Value;
+    $releaseNumber = [int]$r.Captures.Groups[3].Value;
+    
+    $result = "{0} {1} {2}" -f $result, $releaseType, $releaseNumber
+}
+
+Write-Output $result;
+
+exit(0);

--- a/.github/scripts/GenerateVersionNumber.ps1
+++ b/.github/scripts/GenerateVersionNumber.ps1
@@ -1,5 +1,0 @@
-param([string] $Path = "" )
-$dll = Get-Item -Path $Path
-$version = [version]$dll.VersionInfo.ProductVersion
-$versionString = "{0}.{1}.{2}" -f $version.Major, $version.Minor, $version.Build
-Write-Output $versionString

--- a/.github/scripts/GetVersionFromAssemblyInfo.ps1
+++ b/.github/scripts/GetVersionFromAssemblyInfo.ps1
@@ -1,0 +1,6 @@
+param([string] $Path)
+
+$file = Get-Item $Path;
+$fileContent = Get-Content $file.FullName
+$version = [Regex]::Match($fileContent, '(?<!// *)\[assembly: AssemblyVersion\("(\d+\.\d+\.\d+).*"\)\]').Captures.Groups[1].Value
+Write-Output $version

--- a/.github/scripts/UpdateAssemblyVersion.ps1
+++ b/.github/scripts/UpdateAssemblyVersion.ps1
@@ -1,0 +1,49 @@
+param([string] $Path, [string] $Version)
+
+$file = Get-Item $Path;
+Write-Output "File to open is $file"
+Write-Output "Specific version is $Version"
+if(!$Version)
+{
+    Write-Output("Version is not set, exiting!")
+    exit(1);
+}
+
+$versionMatch = [Regex]::Match($Version, "^(\d+\.\d+\.\d+)(?:-([\w-]+))?$");
+
+if (!$versionMatch.Success) {
+    Write-Output("Version should be formatted x.x.x(-beta-1) etc");
+    exit(1);
+}
+
+$baseVersion = $versionMatch.Captures.Groups[1].Value;
+if($versionMatch.Captures.Groups[2].Success)
+{
+    $preReleaseTag = $versionMatch.Captures.Groups[2].Value;
+}
+
+Write-Output "baseVersion = $baseVersion"
+$newAssemblyVersion = 'AssemblyVersion("' + $baseVersion + '.*")'
+Write-Output "AssemblyVersion = $NewAssemblyVersion"
+$newAssemblyFileVersion = 'AssemblyFileVersion("' + $baseVersion + '")'
+Write-Output "AssemblyFileVersion = $newAssemblyFileVersion"
+if($preReleaseTag)
+{
+    $newAssemblyInformationalVersion = 'AssemblyInformationalVersion("' + $baseVersion + '-' + $preReleaseTag + '")'
+}
+else
+{
+    $newAssemblyInformationalVersion = 'AssemblyInformationalVersion("' + $baseVersion + '")'
+}
+Write-Output "AssemblyInformationalVersion = $newAssemblyInformationalVersion"
+
+$TmpFile = $file.FullName + ".tmp"
+Get-Content $file.FullName |
+        ForEach-Object {
+            $_ -replace 'AssemblyVersion\(".*"\)', $newAssemblyVersion } |
+        ForEach-Object {
+            $_ -replace 'AssemblyFileVersion\(".*"\)', $newAssemblyFileVersion } |
+        ForEach-Object {
+            $_ -replace 'AssemblyInformationalVersion\(".*"\)', $newAssemblyInformationalVersion
+        }  > $TmpFile
+move-item $TmpFile $file.FullName -force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         run: nuget restore BuildPackageTest.sln
 
       - name: Build
-        run: msbuild UXAV.Logging.sln /p:Configuration=Release
+        run: msbuild Logging.sln /p:Configuration=Release
 
       - name: Pack Nuget
         run: nuget pack UXAV.Logging/UXAV.Logging.csproj

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,56 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Build and Publish
+name: Build and Release
 
 on:
   push:
-    branches: [ master ]
-
+    branches: [ master, develop ]
+    
 env:
-  # This gets updated automatically	  # This gets updated automatically
-  VERSION: 0.0.0
+  # This gets updated automatically
+  VERSION: version_string
+  VERSION_TITLE: version_title
+  PRERELEASE: false
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
 
+      - name: Get Version Number
+        shell: powershell
+        run: |
+          $version = ./.github/scripts/GetVersionFromAssemblyInfo.ps1 -Path UXAV.Logging/Properties/AssemblyInfo.cs
+          Write-Output "Version is: $version"
+          $versionTitle = ./.github/scripts/CreateVersionTitle.ps1 -Version $version
+          Write-Output "Version title is: $version"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "VERSION_TITLE=$versionTitle" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Create pre-release tag
+        if: github.ref != 'master'
+        if: github.ref != 'refs/heads/master'
+        shell: powershell
+        run: |
+          $version = ./.github/scripts/CreateAvailablePreReleaseVersion.ps1 -Version ${{ env.VERSION }} -PreReleaseName beta
+          Write-Output "Version is: $version"
+          $versionTitle = ./.github/scripts/CreateVersionTitle.ps1 -Version $version
+          Write-Output "Version title is: $versionTitle"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "VERSION_TITLE=$versionTitle" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "PRERELEASE=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Update AssemblyInfo.cs
+        shell: powershell
+        run: ./.github/scripts/UpdateAssemblyVersion.ps1 -Path UXAV.Logging/Properties/AssemblyInfo.cs -Version ${{ env.VERSION }}
+        
       - name: Setup MsBuild
         uses: microsoft/setup-msbuild@v1
-
+        
       - name: Setup NuGet.exe
         uses: NuGet/setup-nuget@v1.0.5
 
@@ -26,21 +58,13 @@ jobs:
         run: nuget sources Add -Name "uxav" -Source https://nuget.pkg.github.com/uxav/index.json -username uxav -password ${{ secrets.GITHUB_TOKEN }} -StorePasswordInClearText
 
       - name: Restore Nuget Packages
-        run: nuget restore Logging.sln
+        run: nuget restore BuildPackageTest.sln
 
       - name: Build
-        run: msbuild Logging.sln /p:Configuration=Release
-
-      # Get version number of the new dll file
-      - name: Set Version Number
-        shell: powershell
-        run: |
-          $version = ./.github/scripts/GenerateVersionNumber.ps1 -Path UXAV.Logging/bin/Release/UXAV.Logging.dll
-          Write-Output "PS returned version: $version"
-          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        run: msbuild UXAV.Logging.sln /p:Configuration=Release
 
       - name: Pack Nuget
-        run: nuget pack UXAV.Logging/UXAV.Logging.csproj -Version ${{ env.VERSION }}
+        run: nuget pack UXAV.Logging/UXAV.Logging.csproj
 
       - name: Push generated package to GitHub registry
         run: nuget push *.nupkg -source "uxav"
@@ -52,7 +76,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ env.VERSION }}
-          release_name: Release v${{ env.VERSION }}
+          release_name: ${{ env.VERSION_TITLE }}
           draft: false
-          prerelease: false
+          prerelease: ${{ env.PRERELEASE }}
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         run: nuget sources Add -Name "uxav" -Source https://nuget.pkg.github.com/uxav/index.json -username uxav -password ${{ secrets.GITHUB_TOKEN }} -StorePasswordInClearText
 
       - name: Restore Nuget Packages
-        run: nuget restore BuildPackageTest.sln
+        run: nuget restore Logging.sln
 
       - name: Build
         run: msbuild Logging.sln /p:Configuration=Release

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,42 +1,66 @@
+# This is a basic workflow to help you get started with Actions
+
 name: Test Build
 
 on:
-  push:
-    branches: [ develop ]
-    pull_request:
-      branches: [ master ]
+  pull_request:
 
 env:
-  # This gets updated automatically	  # This gets updated automatically
-  VERSION: 0.0.0
+  # This gets updated automatically
+  VERSION: version_string
+  VERSION_TITLE: version_title
+  PRERELEASE: false
 
 jobs:
   build:
     runs-on: windows-latest
-
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+      
+      - name: Get Version Number
+        shell: powershell
+        run: |
+          $version = ./.github/scripts/GetVersionFromAssemblyInfo.ps1 -Path UXAV.Logging/Properties/AssemblyInfo.cs
+          Write-Output "Version is: $version"
+          $versionTitle = ./.github/scripts/CreateVersionTitle.ps1 -Version $version
+          Write-Output "Version title is: $version"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "VERSION_TITLE=$versionTitle" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Create pre-release tag
+        if: github.base_ref != 'master'
+        shell: powershell
+        run: |
+          $version = ./.github/scripts/CreateAvailablePreReleaseVersion.ps1 -Version ${{ env.VERSION }} -PreReleaseName beta
+          Write-Output "Version is: $version"
+          $versionTitle = ./.github/scripts/CreateVersionTitle.ps1 -Version $version
+          Write-Output "Version title is: $versionTitle"
+          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "VERSION_TITLE=$versionTitle" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "PRERELEASE=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Update AssemblyInfo.cs
+        shell: powershell
+        run: ./.github/scripts/UpdateAssemblyVersion.ps1 -Path UXAV.Logging/Properties/AssemblyInfo.cs -Version ${{ env.VERSION }}
+        
       - name: Setup MsBuild
         uses: microsoft/setup-msbuild@v1
-
+        
       - name: Setup NuGet.exe
         uses: NuGet/setup-nuget@v1.0.5
 
+      - name: Nuget Add Source
+        run: nuget sources Add -Name "uxav" -Source https://nuget.pkg.github.com/uxav/index.json -username uxav -password ${{ secrets.GITHUB_TOKEN }} -StorePasswordInClearText
+
       - name: Restore Nuget Packages
-        run: nuget restore Logging.sln
+        run: nuget restore UXAV.Logging.sln
 
       - name: Build
-        run: msbuild Logging.sln /p:Configuration=Release
-      
-      # Get version number of the new dll file
-      - name: Set Version Number
-        shell: powershell
-        run: |
-          $version = ./.github/scripts/GenerateVersionNumber.ps1 -Path UXAV.Logging/bin/Release/UXAV.Logging.dll
-          Write-Output "PS returned version: $version"
-          echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        run: msbuild UXAV.Logging.sln /p:Configuration=Release
 
       - name: Pack Nuget
-        run: nuget pack UXAV.Logging/UXAV.Logging.csproj -Version ${{ env.VERSION }}
-        
+        run: nuget pack UXAV.Logging/UXAV.Logging.csproj
+          

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -59,7 +59,7 @@ jobs:
         run: nuget restore UXAV.Logging.sln
 
       - name: Build
-        run: msbuild UXAV.Logging.sln /p:Configuration=Release
+        run: msbuild Logging.sln /p:Configuration=Release
 
       - name: Pack Nuget
         run: nuget pack UXAV.Logging/UXAV.Logging.csproj

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -56,7 +56,7 @@ jobs:
         run: nuget sources Add -Name "uxav" -Source https://nuget.pkg.github.com/uxav/index.json -username uxav -password ${{ secrets.GITHUB_TOKEN }} -StorePasswordInClearText
 
       - name: Restore Nuget Packages
-        run: nuget restore UXAV.Logging.sln
+        run: nuget restore Logging.sln
 
       - name: Build
         run: msbuild Logging.sln /p:Configuration=Release

--- a/UXAV.Logging/Properties/AssemblyInfo.cs
+++ b/UXAV.Logging/Properties/AssemblyInfo.cs
@@ -18,4 +18,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6F84649D-129E-4E0F-9CA7-833EE4F56148")]
 
-[assembly: AssemblyVersion("1.1.5.*")]
+[assembly: AssemblyVersion("1.1.7.*")]
+[assembly: AssemblyFileVersion("1.1.7")]
+[assembly: AssemblyInformationalVersion("1.1.7")]


### PR DESCRIPTION
Build scripts now create pre-release builds and releases when pushed to master. Subsequent pushes to the same version number will increment the number on the end of the tag. Packages are also released with pre-release information.